### PR TITLE
[fix] arrumando comportamento variável dos testes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,6 @@
 {
     "bail": 1,
     "verbose": true,
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "testTimeout": 10000
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "ts-node-dev --inspect --transpile-only --ignore-watch node_modules src/index.ts",
-    "test": "jest --coverage NODE_ENV = 'test'",
+    "test": "jest --coverage --detectOpenHandles NODE_ENV = 'test'",
     "test:unit": "jest src"
   },
   "author": "Lissa Ferreira",

--- a/src/services/ProductService.test.ts
+++ b/src/services/ProductService.test.ts
@@ -27,7 +27,6 @@ describe("Test ProductService", () => {
     const productService = new ProductService();
     const product: Product | null = await productService.getById("999");
 
-    console.log(product);
     expect(product).toEqual(null);
   });
 });

--- a/src/services/UserService.test.ts
+++ b/src/services/UserService.test.ts
@@ -27,7 +27,6 @@ describe("Test UserService", () => {
     const userService = new UserService();
     const user: User | null = await userService.getById("999");
 
-    console.log(user);
     expect(user).toEqual(null);
   });
 });


### PR DESCRIPTION
Nesta PR, arrumo o comportamento variável dos testes, pois alguns falham por um erro de serilização, que ocorria em uma biblioteca interna do Express.

Arrumei adicionando o parâmetro `--detectOpenHandles` no Jest, que faz ele indentificar as promises pendentes, como requisições, e adicionando a configuração:

```json
{
    "testTimeout": 10000
}
```

ao arquivo de configuração do Jest, aumentando o limite de tempo de espera do teste para 10 segundos, garantindo que na maior parte das vezes, as requisições não durem tempo suficiente do Jest cancelar o teste.