### PR TITLE
[fix] melhorando uso de dados dos repositórios

### DIFF
--- a/src/repositories/ProductRepository.ts
+++ b/src/repositories/ProductRepository.ts
@@ -11,13 +11,11 @@ class ProductRepository {
   }
 
   async getProducts(): Promise<Product[]> {
-    await this.update();
     return this.products;
   }
 
   async getById(id: string): Promise<Product | null> {
-    await this.update();
-    return this.products.filter((product) => product.id == id)[0];
+    return this.products.find(product => product.id == id) ?? null
   }
 
   constructor() {

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -11,13 +11,11 @@ class UserRepository {
   }
 
   async getUsers(): Promise<User[]> {
-    await this.update();
     return this.users;
   }
 
   async getById(id: string): Promise<User | null> {
-    await this.update();
-    return this.users.filter((user) => user.id == id)[0];
+    return this.users.find(user => user.id == id) ?? null
   }
 
   constructor() {


### PR DESCRIPTION
Nesta PR, mudo a forma que os repositórios usam os dados do mockend, pegando estes apenas uma vez durante a execução da API.

Isso foi feito para evitar que API chamasse diversas vezes o mockend, e como este é estático, não faz sentido para o escopo do projeto pegar diversas vezes durante a execução.