### PR TITLE
[fix] arrumando valor de totalprice

### DIFF
--- a/src/controllers/CartController.ts
+++ b/src/controllers/CartController.ts
@@ -43,7 +43,7 @@ class CartController {
               // calcular preço de um produto baseado em uma porcentagem, ex: 10% de 100 é 10.
               calculatePercentage(product.price, user.tax).toFixed(2)
             );
-            totalPrice += product.price;
+            totalPrice += product.priceWithTax;
 
             productsWithTax.push(product);
           }


### PR DESCRIPTION
Nesta PR, arrumo o valor de `totalPrice`, item que faz parte da resposta da API à requisição `GET /cart/tax`.

`totalPrice` estava com a soma dos preços dos produtos sem a taxa, que não é o comportamento esperado. Agora, essa soma inclui as taxas.