### PR TITLE
[fix] arrumando a assincronicidade dos repositórios de User e Product

### DIFF
--- a/src/repositories/ProductRepository.ts
+++ b/src/repositories/ProductRepository.ts
@@ -4,6 +4,7 @@ import { EnvVariables } from "../utils/EnvVariables";
 
 class ProductRepository {
   private products: Product[] = [];
+  private updated: boolean = false
   private env = new EnvVariables()
 
   async update() {
@@ -18,11 +19,15 @@ class ProductRepository {
   }
 
   async getProducts(): Promise<Product[]> {
+    if (!this.updated){
+      await this.update();
+      this.updated = true
+    }
     return this.products;
   }
 
   async getById(id: string): Promise<Product | null> {
-    return this.products.find(product => product.id == id) ?? null
+    return (await this.getProducts()).find(product => product.id == id) ?? null
   }
 
   constructor() {

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -4,6 +4,7 @@ import { EnvVariables } from "../utils/EnvVariables";
 
 class UserRepository {
   private users: User[] = [];
+  private updated: boolean = false
   private env = new EnvVariables()
 
   async update() {
@@ -18,15 +19,21 @@ class UserRepository {
   }
 
   async getUsers(): Promise<User[]> {
+    if (!this.updated){
+      await this.update()
+      this.updated = true
+    }
     return this.users;
   }
 
   async getById(id: string): Promise<User | null> {
-    return this.users.find(user => user.id == id) ?? null
+    return (await this.getUsers()).find(user => user.id == id) ?? null
   }
 
   constructor() {
-    this.update();
+    this.update().then(() => {
+      this.updated = true
+    })
   }
 }
 


### PR DESCRIPTION
Nesta PR, arrumo a assincronicidade dos repositórios de User e Product, que geravam um comportamento instável dos testes, pois a requisição pode retornar em tempos diferentes, enviando como resposta o valor padrão de `getUsers()` e `getProducts()`, um array vazio.

Agora, foi adicionada uma trava que impede que esses repositórios retornem as pessoas usuárias ou os produtos antes de pegarem esses dados no mockend.