### PR TITLE
[fix] removendo .env.development não utilizado

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,0 @@
-USERS_SERVER=https://mockend.com/juunegreiros/BE-test-api/users
-PRODUCTS_SERVER=https://mockend.com/juunegreiros/BE-test-api/products


### PR DESCRIPTION
Nesta PR, removo o arquivo `.env.development`, que não é utilizado pelo middleware, podendo ser removido sem problemas.